### PR TITLE
Fix .gitignore ignoring gradle files.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,14 +23,11 @@ run
 /LICENSE-new.txt
 /Paulscode SoundSystem CodecIBXM License.txt
 /Paulscode IBXM Library License.txt
-/gradlew
 /MinecraftForge-Credits.txt
 /forge-1.12.2-14.23.4.2705-changelog.txt
 /CREDITS-fml.txt
 /README.txt
-/gradlew.bat
 /libs/
-/gradle/
 /src/libs/
 classes/
 src/main/resources/235-512.png


### PR DESCRIPTION
Gradle generated scripts and the wrapper .jar are supposed to be included in version control.

> The scripts generated by this task are intended to be committed to your version control system.
This task also generates a small gradle-wrapper.jar bootstrap JAR file and properties file which
should also be committed to your VCS. The scripts delegates to this JAR.

 [Source](https://docs.gradle.org/current/dsl/org.gradle.api.tasks.wrapper.Wrapper.html)